### PR TITLE
[cmake] Allow recursive headers files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,7 @@ include(GNUInstallDirs)
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(sapdragon::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -19,11 +18,10 @@ if (SYSCALL_CPP_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-file(GLOB HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
-
 install(
-    FILES ${HEADER_FILES}
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
 )
 
 install(


### PR DESCRIPTION
Hello @sapdragon !

As I am reviewing your PR https://github.com/conan-io/conan-center-index/pull/27680, I found your CMake is actually ignoring nested folder when installing headers. 

This PR changes from `FILE(GLOB ...)` to `INSTALL(FILES_MATCHING ...)` which covers the case. 

I also updated to use `target_compile_features` instead of `set_target_properties` be allow users using C++23 for instance.

I would recommend you adding a CI file, like Github ACtions, so you can prove your follow PRs. Regards.

Here is my local build log: [windows-build.log](https://github.com/user-attachments/files/23497719/windows-build.log)
